### PR TITLE
change nametext to origin and healthbar uses offset

### DIFF
--- a/game/src/assets/json/characters.json
+++ b/game/src/assets/json/characters.json
@@ -16,10 +16,10 @@
       "offset": {"x": 87, "y": 80}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 5.5}
+        "origin": {"x": 0.5, "y": 5.5}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0, "y": 0}
     }
   },
   "priest_hero": {
@@ -39,10 +39,10 @@
       "offset": {"x": 92, "y": 80}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 5.5}
+        "origin": {"x": 0.5, "y": 5.5}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0, "y": 0}
     }
   },
   "mage_hero":{
@@ -62,10 +62,10 @@
       "offset": {"x": 92, "y": 90}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 5.0}
+        "origin": {"x": 0.5, "y": 4.9}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0, "y": 12}
     }
   },
   "fire_monster":{
@@ -85,10 +85,10 @@
       "offset": {"x": 95, "y": 60}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 5.6}
+        "origin": {"x": 0.5, "y": 5.5}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0, "y": 0}
     }
   },
   "ice_monster":{
@@ -108,10 +108,10 @@
       "offset": {"x": 88, "y": 60}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 5.8}
+        "origin": {"x": 0.5, "y": 5.5}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0.5, "y": 0}
     }
   },
   "golem_monster":{
@@ -131,10 +131,10 @@
       "offset": {"x": 85, "y": 70}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 5.6}
+        "origin": {"x": 0.5, "y": 5.5}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0, "y": 0}
     }
   },
   "spider_monster":{
@@ -154,10 +154,10 @@
       "offset": {"x": 84, "y": 115}
     },
     "nameText": {
-        "offset": {"x": 0.5, "y": 3.5}
+        "origin": {"x": 0.5, "y": 3.9}
     },
     "healthBar": {
-        "offset": {"x": 0.5, "y": -5.8}
+        "offset": {"x": 0, "y": 30}
     }
   }
 }

--- a/game/src/js/objects/Character.js
+++ b/game/src/js/objects/Character.js
@@ -72,11 +72,11 @@ export default class Character extends Phaser.Physics.Arcade.Sprite {
         fontSize: 14,
         fill: '#ffffff',
       });
-      this.handleText.setOrigin(this.props.nameText.offset.x, this.props.nameText.offset.y);
+      this.handleText.setOrigin(this.props.nameText.origin.x, this.props.nameText.origin.y);
       this.handleText.setStroke('#000000', 5);
       scene.physics.world.enable(this.handleText);
     }
-    this.healthBar = scene.add.graphics({x: x, y: y});
+    this.healthBar = scene.add.graphics({x: x + this.props.healthBar.offset.x, y: y + this.props.healthBar.offset.y});
     scene.physics.world.enable(this.healthBar);
     this.drawHealth();
 


### PR DESCRIPTION
It turns out graphics don't have a setOrigin or setOffset methods.  The physics body has a setOffset, but doesn't change the graphics display position.  
1. To be consistent with intent/method I changed the entry/property for nameText to "origin" and updated code for the change.  
2. For graphics display I simply add the "offset" value to the x & y of the character when we initially add the object.

This closes issue #106 and issue #107. 